### PR TITLE
Update registry baseline for vcpkg

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,5 +8,5 @@
     "nlohmann-json",
     "sqlitecpp"
   ],
-  "builtin-baseline": "e6c8c2bc051dc40c39cb4b5b49d180208bdfeda9"
+  "builtin-baseline": "62efe42f53b1886a20cbeb22ee9a27736d20f149"
 }


### PR DESCRIPTION
Addressing vcpkg build issue: https://github.com/CNA-Bld/CarrotJuicer/issues/9.
[Updated the baseline](https://learn.microsoft.com/en-us/vcpkg/commands/update-baseline) with `vcpkg x-update-baseline`.